### PR TITLE
Re-adding Breadcrumbs

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@
 
   checkAndRemove(document.querySelector('.portal_stip_wrapper'));
   checkAndRemove(document.getElementById('corps').querySelector('.portal_div_wrapper'));
-  checkAndRemove(document.getElementById('breadcrumbs'));
   checkAndRemove(document.getElementById('course_ALGAUTOSTUDSSBKa7ae'));
   checkAndRemove(document.getElementById('course_ALGAUTOSTUDENQUETES50ca'));
   checkAndRemove(document.getElementById('course_ALGAUTOSTUDJHNYP9b60'));


### PR DESCRIPTION
A few students who use leho-min requested this to be added again. They find that navigating inside a course is easier using breadcrumbs than spamming the back button in their browser.